### PR TITLE
Fix webpack loader filename and Add encoding option to exmaple html file

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="UTF-8">
 <script src="output/ilib-custom.js"></script>
 <script>
     // all of the classes have been copied to the global scope here, so 

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -15,10 +15,10 @@ module.exports = {
         rules: [{
             test: /\.(js|html)$/,        // Run this loader on all .js files
             use: {
-                loader: "../index.js",
+                loader: "../ilib-webpack-loader.js",
                 options: {
                     // edit these for the list of locales you need
-                    locales: ["en-US", "fr-FR", "de-DE"],
+                    locales: ["en-US", "fr-FR", "de-DE", "ko-KR"],
                     assembly: "dynamic",
                     compilation: "uncompiled"
                 }


### PR DESCRIPTION
Fix some issues in example/
* Fix loader filename to `ilib-webpack-loader.js` in webpack configuration.
* Add encoding option to `index.html` in order to display Korean text properly.
* Add `ko-KR` locale to webpack config