### PR TITLE
Split code into the ilib-webpack-plugin instead

### DIFF
--- a/ilib-scanner.js
+++ b/ilib-scanner.js
@@ -172,7 +172,6 @@ var webpackConfigContents =
     "                    compilation: '" + options.opt.compilation + "',\n" +
     (ilibRoot ? "                    ilibRoot: '" + ilibRoot + "',\n" : "") +
     "                    size: 'custom',\n" +
-    "                    debug: true,\n" +
     "                    target: 'web'\n" +
     "                }\n" +
     "            }\n" +
@@ -187,7 +186,6 @@ var webpackConfigContents =
     "            assembly: '" + options.opt.assembly + "',\n" +
     "            compilation: '" + options.opt.compilation + "',\n" +
     (ilibRoot ? "            ilibRoot: '" + ilibRoot + "',\n" : "") +
-    "                    debug: true,\n" +
     "            size: 'custom'\n" +
     "        })\n" +
     "    ]\n" +

--- a/ilib-webpack-loader.js
+++ b/ilib-webpack-loader.js
@@ -328,7 +328,7 @@ var ilibDataLoader = function(source) {
                     output += "default:\n";
                 }
 
-                output += "        case '" + file + "':\n"
+                output += "        case '" + file + "':\n";
 
                 output += (file === "ilibmanifest") ?
                     "            System.import(/* webpackChunkName: '" + file + "' */ '" + path.join(outputPath, file + ".json") + "').then(function(module) {\n" +
@@ -339,7 +339,7 @@ var ilibDataLoader = function(source) {
 
                 output +=
                     "            });\n" +
-                    "            break;\n"
+                    "            break;\n";
             });
 
             partial = partial.substring(match.index + match[0].length);

--- a/ilib-webpack-loader.js
+++ b/ilib-webpack-loader.js
@@ -288,7 +288,7 @@ var ilibDataLoader = function(source) {
         if ((match = defineLocaleDataPattern.exec(partial)) !== null) {
             // console.log(">>>>>>>>>> found a match");
             output += partial.substring(0, match.index);
-            if (options.assembly === "dynamicdata") {
+            if (options.assembly !== "assembled") {
                 output +=
                     "ilib.WebpackLoader = require('./WebpackLoader.js');\n" +
                     "ilib.setLoaderCallback(ilib.WebpackLoader(ilib));\n" +
@@ -298,9 +298,12 @@ var ilibDataLoader = function(source) {
                 var files = emitLocaleData(this._compilation, options);
                 var outputPath = path.join(outputRoot, "locales");
                 files.forEach(function(locale) {
-                    output += "require('" + path.join(outputPath, locale + (locale === "ilibmanifest" ? ".json" : ".js")) + "');\n";
+                    if (locale !== "ilibmanifest") {
+                        output += "require('" + path.join(outputPath, locale + ".js") + "').installLocale(ilib);\n";
+                    }
                 });
                 output +=
+                    "require('./ilib-unpack.js');\n" +
                     "ilib._dyncode = false;\n" +
                     "ilib._dyndata = false;\n";
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-loader",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "main": "./ilib-webpack-loader.js",
     "bin": {
       "ilib-scanner": "./ilib-scanner.js"


### PR DESCRIPTION
The plugin can run after all of the loading is done, so the code that generates the contents of the .js files should go there instead of here. (The experiment succeeded!)