### PR TITLE
Fixed problems with missing locale data

### DIFF
--- a/examples/ilib-metafile.js
+++ b/examples/ilib-metafile.js
@@ -8,7 +8,4 @@ ilib.NumFmt = require("ilib/lib/NumFmt.js");
 // This unpacks the above classes to the global scope
 require("ilib/lib/ilib-unpack.js");
 
-// Must be at the end of meta file to generate the locale data files
-require("ilib/lib/ilib-getdata.js");
-
 module.exports = ilib;

--- a/ilib-scanner.js
+++ b/ilib-scanner.js
@@ -135,15 +135,14 @@ var metaFileContents =
     " * Do not hand edit or else your changes may be overwritten and lost.\n" +
     " * Instead, re-run the scanner to generate a new version of this file.\n" +
     " */\n\n" +
-    'var ilib = require("' + (ilibRoot || "ilib") + '/lib/ilib.js");\n\n';
+    'var ilib = require("' + (ilibRoot || "ilib") + '");\n\n';
 
 classSet.forEach(function(cls) {
     metaFileContents += 'ilib.' + cls + ' = require("' + (ilibRoot || "ilib") + '/lib/' + cls + '.js");\n';
 });
 
 metaFileContents +=
-    '\nrequire("' + (ilibRoot || "ilib") + '/lib/ilib-unpack.js");\n' +
-    'require("' + (ilibRoot || "ilib") + '/lib/ilib-getdata.js");\n\n' +
+    '\nrequire("' + (ilibRoot || "ilib") + '/lib/ilib-unpack.js");\n\n' +
     'module.exports = ilib;\n';
 
 fs.writeFileSync(outputPath, metaFileContents, "utf-8");

--- a/ilib-webpack-loader.js
+++ b/ilib-webpack-loader.js
@@ -286,6 +286,7 @@ var ilibDataLoader = function(source) {
     var processDefineLocaleData = function (text) {
         var partial = text;
         var output = "";
+        var root = options.ilibRoot || 'ilib';
 
         defineLocaleDataPattern.lastIndex = 0;
         if ((match = defineLocaleDataPattern.exec(partial)) !== null) {
@@ -293,7 +294,7 @@ var ilibDataLoader = function(source) {
             output += partial.substring(0, match.index);
             if (options.assembly !== "assembled") {
                 output +=
-                    "ilib.WebpackLoader = require('./WebpackLoader.js');\n" +
+                    "ilib.WebpackLoader = require('" + root + "/lib/WebpackLoader.js');\n" +
                     "ilib.setLoaderCallback(ilib.WebpackLoader(ilib));\n" +
                     "ilib._dyncode = false;\n" +
                     "ilib._dyndata = true;\n";
@@ -309,7 +310,6 @@ var ilibDataLoader = function(source) {
                     });
                 }
                 output +=
-                    "require('./ilib-unpack.js');\n" +
                     "ilib._dyncode = false;\n" +
                     "ilib._dyndata = false;\n";
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-loader",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "./ilib-webpack-loader.js",
     "bin": {
         "ilib-scanner": "./ilib-scanner.js"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "test": "ant test"
     },
     "dependencies": {
-        "ilib": ">13.0.0",
+        "ilib": "^14.0.0",
         "loader-utils": "^1.0.0",
         "options-parser": "^0.4.0"
     }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "test": "ant test"
     },
     "dependencies": {
-        "ilib": "^14.0.0",
+        "ilib": "^14.1.0",
         "loader-utils": "^1.0.0",
         "options-parser": "^0.4.0"
     }


### PR DESCRIPTION
- deprecate ilib-getdata.js
- added reference to index.js in ilib to auto-load the right Loaders according to the environment
- fix bug where the ilibRoot was not being heeded (which caused the missing locale data)
- depend on ilib 14.1.0 for the webpack support