### PR TITLE
Absolute dir

### DIFF
--- a/ilib-webpack-loader.js
+++ b/ilib-webpack-loader.js
@@ -57,7 +57,7 @@ var ilibDataLoader = function(source) {
     var match;
     var output = "";
     var callback;
-    var outputRoot = path.resolve(path.join(process.cwd(), options.tempDir || 'assets'));
+    var outputRoot = path.resolve(path.isAbsolute(options.tempDir) ? options.tempDir : path.join(process.cwd(), options.tempDir || 'assets'));
 
     options.locales = typeof(options.locales) === "string" ? options.locales.split(",") : (options.locales || [
         "en-AU", "en-CA", "en-GB", "en-IN", "en-NG", "en-PH",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-loader",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./ilib-webpack-loader.js",
     "bin": {
         "ilib-scanner": "./ilib-scanner.js"


### PR DESCRIPTION
If the tempDir option was specified as an absolute path, then this loader didn't work. The fix is simple -- don't prepend the current working directory if the path is absolute. Only do it when it is specified as a relative path.


